### PR TITLE
Fix build on Windows

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -2,3 +2,6 @@ APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_PLATFORM := android-21
 APP_CFLAGS := -Wall -Oz -fomit-frame-pointer -flto
 APP_LDFLAGS := -flto
+ifeq ($(OS),Windows_NT)
+APP_SHORT_COMMANDS := true
+endif


### PR DESCRIPTION
- guard with ifeq to not slow down build needlessly on other platforms