### PR TITLE
Fix SELinux in builds

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,7 +1,7 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_PLATFORM := android-26
 APP_CFLAGS := -Wall -Oz -fomit-frame-pointer -flto
-APP_LDFLAGS := -flto
+APP_LDFLAGS := -flto -T jni/lto_fix.lds
 
 ifeq ($(OS),Windows_NT)
 APP_SHORT_COMMANDS := true

--- a/jni/lto_fix.lds
+++ b/jni/lto_fix.lds
@@ -1,0 +1,12 @@
+SECTIONS {
+  .init_array : {
+    *(SORT_BY_INIT_PRIORITY(.init_array.*))
+    *(EXCLUDE_FILE(*crtend_android.o) .init_array)
+  }
+} INSERT AFTER .fini_array;
+SECTIONS {
+  .fini_array : {
+    *(SORT_BY_INIT_PRIORITY(.fini_array.*))
+    *(EXCLUDE_FILE(*crtend_android.o) .fini_array)
+  }
+} INSERT BEFORE .init_array;


### PR DESCRIPTION
- Magisk's Application.mk uses lto_fix.lds, which was missing here, resulting in (at least) SELinux functionality being broken on direct ndk-box-kitchen builds of busybox